### PR TITLE
feat: 안드로이드 FCM 푸시 추가 (디바이스 토큰 형식으로 APNs/FCM 분기)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ config.py
 
 apple_push/
 
+# Firebase 서비스 계정 비밀키 (FCM) — 커밋 금지
+firebase/
+*firebase-adminsdk*.json
+
 #.env
 *.env
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,6 +28,9 @@ AUTH_KEY_ID = Config.AUTH_KEY_ID
 APP_BUNDLE_ID = Config.APP_BUNDLE_ID
 IS_PRODUCTION = Config.IS_PRODUCTION
 
+# FCM (Android) - Firebase 서비스 계정 키 경로
+FIREBASE_CREDENTIALS_PATH = getattr(Config, "FIREBASE_CREDENTIALS_PATH", "")
+
 
 
 class Settings(BaseModel):

--- a/app/sample_config.py
+++ b/app/sample_config.py
@@ -7,9 +7,12 @@ class Config(object):
     OLLAMA_URL = 'http://localhost:11434'
     OLLAMA_MODEL = 'gemma3:4b'
 
-    # Push Alarm
+    # Push Alarm (APNs - iOS)
     AUTH_KEY_PATH = '' # .p8 파일의 경로
     TEAM_ID = '' # Apple Developer Team ID
     AUTH_KEY_ID = '' # .p8 인증 키 ID
     APP_BUNDLE_ID = '' # 앱의 Bundle ID
     IS_PRODUCTION = True # 프로덕션 환경 여부
+
+    # Push Alarm (FCM - Android)
+    FIREBASE_CREDENTIALS_PATH = '' # Firebase 서비스 계정 .json 경로 (없으면 FCM 비활성화)

--- a/app/services/fcm_pushalarm.py
+++ b/app/services/fcm_pushalarm.py
@@ -1,0 +1,108 @@
+"""
+FCM(Firebase Cloud Messaging) 푸시 — 안드로이드용.
+
+기존 APNs(pushalarm.py)와 짝을 이루는 송신기. iOS는 APNs, 안드로이드는 FCM으로
+보내야 하는데 두 토큰은 호환되지 않으므로, device_token 형식으로 플랫폼을 판별한다
+(APNs 토큰은 순수 hex, FCM 토큰은 ':'/'_'/'-' 포함).
+
+firebase-admin / 서비스계정 키가 없으면 자동 비활성화되고, 앱·APNs는 정상 동작한다.
+"""
+
+import os
+import re
+import asyncio
+import logging
+
+from app import FIREBASE_CREDENTIALS_PATH
+
+logger = logging.getLogger(__name__)
+
+# firebase-admin은 선택 의존성처럼 다룬다(미설치 시 앱은 정상 기동).
+try:
+    import firebase_admin
+    from firebase_admin import credentials, messaging
+    _FIREBASE_IMPORTABLE = True
+except ImportError:  # pragma: no cover
+    firebase_admin = None
+    credentials = None
+    messaging = None
+    _FIREBASE_IMPORTABLE = False
+
+
+def is_apns_token(token: str) -> bool:
+    """
+    iOS APNs 디바이스 토큰 여부.
+
+    iOS AppDelegate가 `%02.2hhx`로 만들어 보내므로 APNs 토큰은 순수 16진수다.
+    FCM 등록 토큰은 항상 ':'(및 '_','-')를 포함하므로 순수 hex가 아니다.
+    """
+    if not token:
+        return False
+    return re.fullmatch(r"[0-9a-fA-F]{32,}", token) is not None
+
+
+class FCMPusher:
+    """firebase-admin(HTTP v1)로 FCM 푸시를 전송. (레거시 서버키 미사용)"""
+
+    def __init__(self):
+        self._app = None
+        self.ready = False
+
+    def init(self):
+        """앱/서비스 최초 import 시 1회 초기화. 키 없으면 비활성화."""
+        if self.ready:
+            return
+        if not _FIREBASE_IMPORTABLE:
+            logger.warning("[FCM] firebase-admin 미설치 — FCM 비활성화 (pip install firebase-admin)")
+            return
+        if not FIREBASE_CREDENTIALS_PATH or not os.path.exists(FIREBASE_CREDENTIALS_PATH):
+            logger.warning("[FCM] 서비스 계정 키 없음(%s) — FCM 비활성화", FIREBASE_CREDENTIALS_PATH)
+            return
+        try:
+            cred = credentials.Certificate(FIREBASE_CREDENTIALS_PATH)
+            # 이미 default app이 있으면 재사용
+            try:
+                self._app = firebase_admin.get_app()
+            except ValueError:
+                self._app = firebase_admin.initialize_app(cred)
+            self.ready = True
+            logger.info("[FCM] 초기화 완료")
+        except Exception as e:  # pragma: no cover
+            logger.error("[FCM] 초기화 실패: %s", e)
+
+    async def send_notification(self, device_token: str, body: str,
+                                from_user_id: str = None, level: str = None) -> bool:
+        """
+        단일 안드로이드 기기로 FCM 푸시.
+
+        notification(표시) + data(type=family_alert, from_user_id, level)를 함께 전송.
+        firebase-admin은 동기 라이브러리라 to_thread로 감싼다. 성공 여부 반환.
+        """
+        if not self.ready:
+            logger.warning("[FCM] 미초기화 — 전송 생략")
+            return False
+
+        data = {"type": "family_alert"}
+        if from_user_id is not None:
+            data["from_user_id"] = str(from_user_id)
+        if level is not None:
+            data["level"] = str(level)
+
+        message = messaging.Message(
+            token=device_token,
+            notification=messaging.Notification(title="위허메 가족 알림", body=body),
+            data=data,
+            android=messaging.AndroidConfig(priority="high"),
+        )
+
+        try:
+            msg_id = await asyncio.to_thread(messaging.send, message)
+            logger.info("[FCM] 전송 성공 token=%s… id=%s", device_token[:8], msg_id)
+            return True
+        except Exception as e:
+            logger.warning("[FCM] 전송 실패 token=%s… err=%s", device_token[:8], e)
+            return False
+
+
+# 싱글톤 인스턴스
+fcm_pusher = FCMPusher()

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -24,13 +24,21 @@ from app.schemas.family_group import (
 )
 # pushalarm.py와 동일한 import 방식 사용
 from app import AUTH_KEY_PATH, TEAM_ID, AUTH_KEY_ID, APP_BUNDLE_ID, IS_PRODUCTION
+# 안드로이드 FCM 송신기 + 토큰 플랫폼 판별
+from app.services.fcm_pushalarm import fcm_pusher, is_apns_token
 
 
 class NotificationService:
     def __init__(self):
         self.db_dependency = get_db
         self._init_apns_client()
-    
+        self._init_fcm_client()
+
+    def _init_fcm_client(self):
+        """FCM(firebase-admin) 초기화 - 안드로이드 푸시용. 키 없으면 비활성화."""
+        self.fcm_pusher = fcm_pusher
+        self.fcm_pusher.init()
+
     def _init_apns_client(self):
         """APNs 클라이언트 초기화 - pushalarm.py와 동일한 방식"""
         try:
@@ -188,11 +196,13 @@ class NotificationService:
                 
                 if not notification_enabled or notification_enabled.enabled:
                     # APNs 푸시 알림 전송
-                    success = await self._send_apns_notification(
+                    success = await self._send_push_notification(
                         device_token=member.device_token,
                         sender_nickname=sender_info.nickname if sender_info else "구성원",
                         danger_type=request.danger_type,
-                        message=request.message
+                        message=request.message,
+                        from_user_id=request.from_user_id,
+                        level="danger"
                     )
                     
                     if success:
@@ -235,7 +245,55 @@ class NotificationService:
         finally:
             db.close()
     
-    async def _send_apns_notification(self, device_token: str, sender_nickname: str, 
+    async def _send_push_notification(self, device_token: str, sender_nickname: str,
+                                      danger_type: str, message: Optional[str],
+                                      from_user_id: Optional[str] = None,
+                                      level: Optional[str] = None):
+        """
+        디바이스 토큰 형식으로 플랫폼을 판별해 푸시를 분기 전송한다.
+          - iOS  (순수 hex 토큰)  → APNs (기존 그대로)
+          - 안드로이드 (그 외)     → FCM (firebase-admin)
+        """
+        if is_apns_token(device_token):
+            return await self._send_apns_notification(
+                device_token=device_token,
+                sender_nickname=sender_nickname,
+                danger_type=danger_type,
+                message=message,
+            )
+        return await self._send_fcm_notification(
+            device_token=device_token,
+            sender_nickname=sender_nickname,
+            danger_type=danger_type,
+            message=message,
+            from_user_id=from_user_id,
+            level=level,
+        )
+
+    async def _send_fcm_notification(self, device_token: str, sender_nickname: str,
+                                     danger_type: str, message: Optional[str],
+                                     from_user_id: Optional[str] = None,
+                                     level: Optional[str] = None):
+        """실제 FCM(안드로이드) 푸시 전송 — APNs와 동일한 본문 구성."""
+        try:
+            # 메시지 구성 (APNs와 동일)
+            body = f"{sender_nickname}님이 {danger_type} 상황입니다."
+            if message:
+                body += f" 메시지: {message}"
+
+            success = await self.fcm_pusher.send_notification(
+                device_token=device_token,
+                body=body,
+                from_user_id=from_user_id,
+                level=level,
+            )
+            print(f"[FCM] Notification sent to {device_token}: {success}")
+            return success
+        except Exception as e:
+            print(f"[FCM] Error sending notification to {device_token}: {e}")
+            return False
+
+    async def _send_apns_notification(self, device_token: str, sender_nickname: str,
                                danger_type: str, message: Optional[str]):
         """실제 APNs 푸시 알림 전송"""
         try:
@@ -243,7 +301,7 @@ class NotificationService:
             body = f"{sender_nickname}님이 {danger_type} 상황입니다."
             if message:
                 body += f" 메시지: {message}"
-            
+
             request = NotificationRequest(
                 device_token=device_token,
                 message={
@@ -354,11 +412,13 @@ class NotificationService:
                 
                 if not notification_enabled or notification_enabled.enabled:
                     # APNs 푸시 알림 전송
-                    success = await self._send_apns_notification(
+                    success = await self._send_push_notification(
                         device_token=member.device_token,
                         sender_nickname=user_info.nickname if user_info else "구성원",
                         danger_type="위험 상황",
-                        message=f"위험 횟수가 {request.danger_count}회로 증가했습니다"
+                        message=f"위험 횟수가 {request.danger_count}회로 증가했습니다",
+                        from_user_id=request.user_id,
+                        level="danger"
                     )
                     
                     if success:
@@ -495,11 +555,13 @@ class NotificationService:
                 
                 if not notification_enabled or notification_enabled.enabled:
                     # APNs 푸시 알림 전송
-                    success = await self._send_apns_notification(
+                    success = await self._send_push_notification(
                         device_token=member.device_token,
                         sender_nickname=user_info.nickname if user_info else "구성원",
                         danger_type="경고 상황",
-                        message=f"경고 횟수가 {request.warning_count}회로 증가했습니다"
+                        message=f"경고 횟수가 {request.warning_count}회로 증가했습니다",
+                        from_user_id=request.user_id,
+                        level="warning"
                     )
                     
                     if success:


### PR DESCRIPTION
## 개요

기존 **APNs(iOS) 전용** 가족 알림에 **안드로이드 FCM** 경로를 추가했습니다.
`device_token` 형식으로 플랫폼을 판별해 **iOS → APNs, Android → FCM** 으로 자동 분기합니다.
APNs 경로/스키마/DB/클라이언트는 변경하지 않았습니다.

## 변경 사항

- **`app/services/fcm_pushalarm.py`** (신규): `firebase-admin`(HTTP v1) 기반 `FCMPusher` + `is_apns_token()`.
  - APNs 토큰은 순수 hex, FCM 토큰은 `:`/`_`/`-` 포함 → 형식으로 플랫폼 판별.
  - `notification` + `data(type=family_alert, from_user_id, level)` 전송.
  - firebase-admin/서비스 계정 키가 없으면 자동 비활성화(앱·APNs 무영향).
- **`app/services/notification_service.py`**: `_send_push_notification` 디스패처 추가.
  - `danger` / `auto-danger` / `auto-warning` 전송 루프를 디스패처로 교체(`from_user_id`·`level` 전달).
  - APNs 리프(`_send_apns_notification`)는 **변경 없음**.
- **설정**: `FIREBASE_CREDENTIALS_PATH` 추가(`sample_config.py`, `app/__init__.py`), `.gitignore`에 키 제외.

## 왜

iOS는 native APNs hex 토큰, 안드로이드는 FCM 토큰을 **같은 `device_token` 필드**로 보냅니다.
두 토큰은 호환되지 않습니다(`firebase-admin`은 FCM 토큰만, `aioapns`는 APNs 토큰만 전송 가능).
따라서 애플·안드로이드 둘 다 도달하려면 토큰별 분기가 필요합니다. (현재 코드는 APNs-only라 안드로이드 FCM 토큰엔 전송 실패)

## 리뷰 참고

- **실제 발송 조건**: Firebase 콘솔(프로젝트 `weheome`) 서비스 계정 JSON을 `FIREBASE_CREDENTIALS_PATH`에 지정 + `pip install firebase-admin`. 미설정 시 FCM만 비활성화되고 iOS/나머지 API는 정상.
- **플랫폼 판별을 토큰 형식 추론**으로 처리(스키마/DB/클라 무변경, 범위 최소화). 장기적으로는 `users.platform` 컬럼이 더 견고 — 별도 작업 제안.
- `/api/notifications/test`는 의도상 APNs 전용으로 유지.

## 테스트

- `is_apns_token`: 64-hex→APNs, FCM(콜론 포함)→FCM, 빈값→False ✅
- `_send_push_notification` 라우팅 목 테스트: iOS 토큰→APNs 리프, 안드로이드 토큰→FCM 리프(+`from_user_id`/`level` data 전달) ✅
- 키 없을 때 graceful 비활성화 + `notification_service`/전체 라우터 정상 임포트 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android push notification support alongside existing iOS notifications.
  * Notifications now automatically route to the correct platform based on the device token.

* **Bug Fixes**
  * Improved handling of alert and warning messages so they’re delivered with the correct notification details.
  * Reduced the risk of misconfigured credentials being committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->