### PR TITLE
fix: notifications danger/warning-count 500 (이벤트 루프 중첩) 해결

### DIFF
--- a/app/api/endpoints/notifications.py
+++ b/app/api/endpoints/notifications.py
@@ -191,7 +191,7 @@ async def update_danger_count_with_notification(request: UpdateDangerCountReques
     - 업데이트 결과 및 알림 전송 여부
     """
     try:
-        success = notification_service.update_danger_count_with_notification(request)
+        success = await notification_service.update_danger_count_with_notification(request)
         if success:
             return {
                 "success": True,
@@ -260,7 +260,7 @@ async def update_warning_count_with_notification(request: UpdateWarningCountRequ
     - 업데이트 결과 및 알림 전송 여부
     """
     try:
-        success = notification_service.update_warning_count_with_notification(request)
+        success = await notification_service.update_warning_count_with_notification(request)
         if success:
             return {
                 "success": True,

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -456,7 +456,7 @@ class NotificationService:
         finally:
             db.close()
     
-    def update_danger_count_with_notification(self, request: UpdateDangerCountRequest) -> bool:
+    async def update_danger_count_with_notification(self, request: UpdateDangerCountRequest) -> bool:
         """위험 카운트 업데이트와 동시에 자동 알림 발송"""
         db = self._get_db()
         
@@ -481,19 +481,16 @@ class NotificationService:
             
             # 3. 카운트가 증가했을 때만 자동 알림 발송
             if request.danger_count > current_count.danger_count:
-                import asyncio
-                
-                # 비동기 알림 발송을 동기 함수에서 실행
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                
                 auto_notification = AutoDangerNotificationRequest(
                     user_id=request.user_id,
                     danger_count=request.danger_count
                 )
-                
-                loop.run_until_complete(self.send_auto_danger_notification(auto_notification))
-                loop.close()
+                # 이미 실행 중인 이벤트 루프에서 그대로 await (새 루프 생성 금지)
+                # 알림은 best-effort: 그룹 없음/전송 실패해도 카운트 업데이트는 성공 유지
+                try:
+                    await self.send_auto_danger_notification(auto_notification)
+                except Exception as e:
+                    print(f"[danger-count] 자동 알림 생략/실패(무시): {e}")
             
             return True
             
@@ -599,7 +596,7 @@ class NotificationService:
         finally:
             db.close()
     
-    def update_warning_count_with_notification(self, request: UpdateWarningCountRequest) -> bool:
+    async def update_warning_count_with_notification(self, request: UpdateWarningCountRequest) -> bool:
         """경고 카운트 업데이트와 동시에 자동 알림 발송"""
         db = self._get_db()
         
@@ -624,19 +621,16 @@ class NotificationService:
             
             # 3. 카운트가 증가했을 때만 자동 알림 발송
             if request.warning_count > current_count.warning_count:
-                import asyncio
-                
-                # 비동기 알림 발송을 동기 함수에서 실행
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                
                 auto_notification = AutoWarningNotificationRequest(
                     user_id=request.user_id,
                     warning_count=request.warning_count
                 )
-                
-                loop.run_until_complete(self.send_auto_warning_notification(auto_notification))
-                loop.close()
+                # 이미 실행 중인 이벤트 루프에서 그대로 await (새 루프 생성 금지)
+                # 알림은 best-effort: 그룹 없음/전송 실패해도 카운트 업데이트는 성공 유지
+                try:
+                    await self.send_auto_warning_notification(auto_notification)
+                except Exception as e:
+                    print(f"[warning-count] 자동 알림 생략/실패(무시): {e}")
             
             return True
             


### PR DESCRIPTION
## 개요

`PUT /api/notifications/danger-count` · `warning-count`가 **매 호출 500**(`Cannot run the event loop while another loop is running`)을 내던 버그 수정. 이 때문에 카운트 증가 시 자동 알림이 **발송 직전 항상 실패** → 푸시(FCM/APNs)가 실제로 안 나가고 있었습니다.

## 원인

`update_danger_count_with_notification` / `update_warning_count_with_notification`는 **sync** 메서드인데, **async 엔드포인트** 안에서 호출되면서 내부에서 `asyncio.new_event_loop()` + `loop.run_until_complete(...)`로 **새 이벤트 루프**를 돌립니다. uvicorn의 이벤트 루프가 이미 실행 중이라 충돌 → `RuntimeError` → 500.

## 변경

- 두 메서드를 `async def`로 변경하고, 새 루프 대신 `await self.send_auto_*_notification(...)` (코드의 다른 알림 메서드들과 동일한 방식).
- 엔드포인트(`notifications.py`)에서 `await`로 호출.
- 자동 알림을 **best-effort**(try/except)로 감싸, 그룹 없음(`USER_NOT_IN_GROUP`)·전송 실패 시에도 **카운트 업데이트는 200으로 성공** 처리.

## 테스트

- 버그 재현: 실행 중 루프 안에서 `run_until_complete` → 동일 에러 확인 ✅
- 수정 검증: 실행 중 루프에서 `await update_danger_count_with_notification` → 정상(반환 `True`, 알림 호출) ✅
- best-effort: 그룹 없음 → 알림 예외 무시, 카운트 업데이트 `True`(200) ✅
- `new_event_loop`/`run_until_complete` 잔여 0 ✅

## 배포

서버 재배포 후 적용됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
