### PR TITLE
feat: notification_logs에 success 컬럼 추가 (수신자별 전송 성공/실패 기록)

### DIFF
--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -212,8 +212,8 @@ class NotificationService:
                     db.execute(text(
                         """
                         INSERT INTO notification_logs 
-                        (from_user_id, to_user_id, group_id, notification_type, message, sent_at)
-                        VALUES (:from_user_id, :to_user_id, :group_id, :notification_type, :message, :sent_at)
+                        (from_user_id, to_user_id, group_id, notification_type, message, success, sent_at)
+                        VALUES (:from_user_id, :to_user_id, :group_id, :notification_type, :message, :success, :sent_at)
                         """
                     ), {
                         "from_user_id": request.from_user_id,
@@ -221,6 +221,7 @@ class NotificationService:
                         "group_id": sender_group.group_id,
                         "notification_type": "danger",
                         "message": f"{request.danger_type}: {request.message or ''}",
+                        "success": success,
                         "sent_at": datetime.now()
                     })
             
@@ -428,8 +429,8 @@ class NotificationService:
                     db.execute(text(
                         """
                         INSERT INTO notification_logs 
-                        (from_user_id, to_user_id, group_id, notification_type, message, sent_at)
-                        VALUES (:from_user_id, :to_user_id, :group_id, :notification_type, :message, :sent_at)
+                        (from_user_id, to_user_id, group_id, notification_type, message, success, sent_at)
+                        VALUES (:from_user_id, :to_user_id, :group_id, :notification_type, :message, :success, :sent_at)
                         """
                     ), {
                         "from_user_id": request.user_id,
@@ -437,6 +438,7 @@ class NotificationService:
                         "group_id": user_group.group_id,
                         "notification_type": "danger",
                         "message": f"위험 횟수 증가 (현재: {request.danger_count}회)",
+                        "success": success,
                         "sent_at": notification_time
                     })
             
@@ -568,8 +570,8 @@ class NotificationService:
                     db.execute(text(
                         """
                         INSERT INTO notification_logs 
-                        (from_user_id, to_user_id, group_id, notification_type, message, sent_at)
-                        VALUES (:from_user_id, :to_user_id, :group_id, :notification_type, :message, :sent_at)
+                        (from_user_id, to_user_id, group_id, notification_type, message, success, sent_at)
+                        VALUES (:from_user_id, :to_user_id, :group_id, :notification_type, :message, :success, :sent_at)
                         """
                     ), {
                         "from_user_id": request.user_id,
@@ -577,6 +579,7 @@ class NotificationService:
                         "group_id": user_group.group_id,
                         "notification_type": "warning",
                         "message": f"경고 횟수 증가 (현재: {request.warning_count}회)",
+                        "success": success,
                         "sent_at": notification_time
                     })
             


### PR DESCRIPTION
## 개요

`notification_logs`에 **수신자별 전송 성공/실패**를 남기는 `success` 컬럼을 추가합니다.
지금까지는 "보냈다"만 기록돼 **누구한테 실패했는지**(BadDeviceToken·stale 토큰 등) 알 수 없었는데, 이제 행 단위로 성공 여부가 남습니다.

## 변경

- `notification_service.py`의 알림 로그 INSERT 3곳(`send_danger_notification`, `send_auto_danger_notification`, `send_auto_warning_notification`)에 `success` 컬럼+값 추가.
- `success`는 이미 계산돼 있는 전송 결과 bool(`_send_push_notification` 반환값)을 그대로 기록 — 추가 로직 없음.

## ⚠️ 배포 전 DB 마이그레이션 필수

코드 배포 **전에** 아래 ALTER를 먼저 실행하세요. 안 하면 INSERT가 `Unknown column 'success'`로 실패합니다.

```sql
ALTER TABLE notification_logs
  ADD COLUMN success BOOLEAN NULL DEFAULT NULL AFTER message;
```
(기존 행은 `NULL` = 당시 성공여부 미기록, 신규 행부터 `0/1` 기록.)

## 테스트

- 전송 실패 시 `success=False`가 INSERT 파라미터에 실리는지 목 테스트로 확인 ✅
- 3개 INSERT 모두 컬럼/파라미터 일관성 확인, 컴파일 OK ✅

## 활용 예시

```sql
-- 최근 실패한 전달만 추리기
SELECT from_user_id, to_user_id, notification_type, success, sent_at
FROM notification_logs
WHERE success = 0
ORDER BY sent_at DESC;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification delivery logs so each recipient’s success status is now saved correctly for danger and warning alerts.
  * Improved reliability of manual group danger notifications as well as automatic danger and warning notifications when counts increase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->