### PR TITLE
feat: POST /api/auth/device-token 추가 (onNewToken 토큰 갱신)

### DIFF
--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -1,0 +1,59 @@
+from fastapi import APIRouter, HTTPException, Depends, status
+from sqlalchemy.orm import Session
+from datetime import datetime
+import logging
+
+from app.core.database import get_db
+from app.schemas.kakao import DeviceTokenRegisterRequest, DeviceTokenUpdateResponse
+from app.repositories.user_repository import get_user_repository
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.post(
+    "/device-token",
+    response_model=DeviceTokenUpdateResponse,
+    summary="디바이스 토큰 등록/갱신 (user_id 기반)",
+    description="클라 onNewToken에서 호출 — FCM/APNs 토큰이 갱신되면 서버에 다시 등록한다. "
+                "(최초 토큰은 카카오 로그인 시 device_token으로 함께 전송됨)",
+)
+async def register_device_token(
+    request: DeviceTokenRegisterRequest,
+    db: Session = Depends(get_db),
+):
+    """
+    디바이스 토큰 등록/갱신 API
+
+    - user_id: 사용자 ID
+    - device_token: 새 FCM/APNs 디바이스 토큰
+
+    family_group API와 동일하게 user_id 기반(세션의 user_id 사용).
+    """
+    user_repo = get_user_repository(db)
+    user = user_repo.get_by_user_id(request.user_id)
+
+    if not user or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="사용자를 찾을 수 없음",
+        )
+
+    try:
+        user.device_token = request.device_token
+        user.updated_at = datetime.utcnow()
+        db.commit()
+        db.refresh(user)
+    except Exception as e:
+        db.rollback()
+        logger.error(f"디바이스 토큰 갱신 실패: user_id={request.user_id}, error={str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="디바이스 토큰 갱신 실패",
+        )
+
+    logger.info(f"디바이스 토큰 갱신(POST /auth/device-token): user_id={request.user_id}")
+    return DeviceTokenUpdateResponse(
+        success=True,
+        message="디바이스 토큰이 갱신되었습니다",
+    )

--- a/app/api/routers.py
+++ b/app/api/routers.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api.endpoints import check_fraud, family_group, check_fraud_ws, kakao_login, notifications
+from app.api.endpoints import check_fraud, family_group, check_fraud_ws, kakao_login, notifications, auth
 
 router = APIRouter()
 
@@ -8,3 +8,4 @@ router.include_router(family_group.router, prefix="/family_group", tags=["family
 router.include_router(notifications.router, prefix="/notifications", tags=["notifications"])
 router.include_router(check_fraud_ws.router, prefix="/ws/fraud", tags=["fraud-websocket"])
 router.include_router(kakao_login.router, prefix="/auth/kakao", tags=["kakao-login"])
+router.include_router(auth.router, prefix="/auth", tags=["auth"])

--- a/app/schemas/kakao.py
+++ b/app/schemas/kakao.py
@@ -25,8 +25,14 @@ class LoginResponse(BaseModel):
 
 # 디바이스 토큰 업데이트 스키마
 class DeviceTokenUpdateRequest(BaseModel):
-    """디바이스 토큰 업데이트 요청"""
+    """디바이스 토큰 업데이트 요청 (JWT 인증, PATCH /auth/kakao/device-token)"""
     device_token: str = Field(..., description="새로운 APNs 디바이스 토큰")
+
+# 디바이스 토큰 등록/갱신 (user_id 기반 — 클라 onNewToken)
+class DeviceTokenRegisterRequest(BaseModel):
+    """디바이스 토큰 등록/갱신 요청 (POST /auth/device-token)"""
+    user_id: str = Field(..., description="사용자 ID (UUID)")
+    device_token: str = Field(..., description="FCM/APNs 디바이스 토큰")
 
 class DeviceTokenUpdateResponse(BaseModel):
     """디바이스 토큰 업데이트 응답"""


### PR DESCRIPTION
## 개요

클라이언트(`onNewToken`)가 호출하는 **`POST /api/auth/device-token {user_id, device_token}`** 엔드포인트를 백엔드에 추가합니다. 지금까지 이게 없어서 **404로 조용히 실패**했고, 그래서 *재로그인 없이 FCM/APNs 토큰만 바뀌면* 서버가 갱신을 못 받아 stale 토큰이 쌓였습니다.

## 배경

- **로그인 시 토큰 갱신은 이미 동작**합니다: 클라가 `loginWithKakao`에서 FCM 토큰을 `device_token`으로 함께 보내고(`POST /api/auth/kakao/token`), 백엔드가 `update_user_profile`에서 덮어씁니다.
- 하지만 **토큰 갱신 전용 경로**가 없었습니다. 클라 `BackendApi.updateDeviceToken`은 `POST /api/auth/device-token {user_id, device_token}`을 호출하는데(코드 주석에도 "BE 신규 엔드포인트 필요"), 백엔드엔 `PATCH /api/auth/kakao/device-token`(JWT 인증)밖에 없어서 404였습니다.

## 변경

- `app/api/endpoints/auth.py` (신규): `POST /device-token` — `user_id`로 유저 조회 후 `device_token` 갱신. family_group API와 동일하게 **user_id 기반**(클라가 세션 user_id를 body에 실어 보냄, 별도 JWT 없음).
- `app/schemas/kakao.py`: `DeviceTokenRegisterRequest {user_id, device_token}` 추가.
- `app/api/routers.py`: `/auth` prefix로 라우터 등록 (`/api/auth/device-token`). 기존 `/auth/kakao/*`와 충돌 없음.

## 테스트

- `POST /api/auth/device-token` 라우트 등록 + 기존 `PATCH /api/auth/kakao/device-token` 유지 확인 ✅
- 정상: 200 + `device_token` 실제 갱신 ✅ / 없는 유저: 404 ✅ / `user_id` 누락: 422 ✅

## 참고

- 인증 모델은 기존 family_group/notifications와 동일한 **user_id 기반**입니다(엄격한 JWT 아님). 더 견고하게 하려면 추후 JWT(`?token=`) 기반으로 통일하는 개선 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to register or update a device token for a user.
  * Connected the new authentication routes so device token requests are now available in the app.

* **Bug Fixes**
  * Invalid or inactive users are now rejected with a clear not-found response.
  * Database update failures are handled safely, with rollback and a generic error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->