### PR TITLE
feat: 가족 알림 빈도 제한 (1시간 내 3회 이상 감지 시 전송)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,6 +31,11 @@ IS_PRODUCTION = Config.IS_PRODUCTION
 # FCM (Android) - Firebase 서비스 계정 키 경로
 FIREBASE_CREDENTIALS_PATH = getattr(Config, "FIREBASE_CREDENTIALS_PATH", "")
 
+# 가족 알림 빈도 제한 (감지 N회/윈도우 이상일 때만 전송)
+ALERT_THRESHOLD = getattr(Config, "ALERT_THRESHOLD", 3)
+ALERT_WINDOW_MINUTES = getattr(Config, "ALERT_WINDOW_MINUTES", 60)
+ALERT_COOLDOWN_MINUTES = getattr(Config, "ALERT_COOLDOWN_MINUTES", 60)
+
 
 
 class Settings(BaseModel):

--- a/app/sample_config.py
+++ b/app/sample_config.py
@@ -16,3 +16,8 @@ class Config(object):
 
     # Push Alarm (FCM - Android)
     FIREBASE_CREDENTIALS_PATH = '' # Firebase 서비스 계정 .json 경로 (없으면 FCM 비활성화)
+
+    # 가족 알림 빈도 제한 (감지가 잦을 때만 보내기)
+    ALERT_THRESHOLD = 3         # 윈도우 내 감지 이 횟수 이상이면 알림 전송
+    ALERT_WINDOW_MINUTES = 60   # 감지 집계 윈도우 (분)
+    ALERT_COOLDOWN_MINUTES = 60 # 한 번 보낸 뒤 재전송 최소 간격 (분)

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -4,8 +4,9 @@ APNs 푸시 알림 서비스
 그룹 내 구성원 간 위험 상황 알림 전송 및 알림 설정 관리
 """
 
+import logging
 from typing import List, Optional
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import uuid4
 from sqlalchemy.orm import Session
 from sqlalchemy import text
@@ -24,8 +25,12 @@ from app.schemas.family_group import (
 )
 # pushalarm.py와 동일한 import 방식 사용
 from app import AUTH_KEY_PATH, TEAM_ID, AUTH_KEY_ID, APP_BUNDLE_ID, IS_PRODUCTION
+# 가족 알림 빈도 제한 설정
+from app import ALERT_THRESHOLD, ALERT_WINDOW_MINUTES, ALERT_COOLDOWN_MINUTES
 # 안드로이드 FCM 송신기 + 토큰 플랫폼 판별
 from app.services.fcm_pushalarm import fcm_pusher, is_apns_token
+
+logger = logging.getLogger(__name__)
 
 
 class NotificationService:
@@ -60,7 +65,55 @@ class NotificationService:
     def _get_db(self) -> Session:
         """데이터베이스 세션 가져오기"""
         return next(self.db_dependency())
-    
+
+    def _should_send_alert(self, db: Session, user_id: str, notification_type: str) -> bool:
+        """
+        감지 빈도 제한: 이번 감지를 기록하고, 윈도우 내 감지가 임계 이상이며
+        쿨다운이 지났을 때만 True(전송)를 반환한다.
+          - 기본값: ALERT_WINDOW_MINUTES(60분) 내 ALERT_THRESHOLD(3회) 이상 → 전송
+          - 한 번 보내면 ALERT_COOLDOWN_MINUTES(60분) 동안 재전송 안 함
+        판정 실패(예: detection_events 테이블 없음) 시에는 기존처럼 전송(fail-open).
+        """
+        try:
+            now = datetime.now()
+            # 1) 이번 감지 기록
+            db.execute(text(
+                "INSERT INTO detection_events (user_id, notification_type, occurred_at) "
+                "VALUES (:user_id, :type, :now)"
+            ), {"user_id": user_id, "type": notification_type, "now": now})
+            db.commit()
+
+            # 2) 윈도우 내 감지 횟수
+            window_start = now - timedelta(minutes=ALERT_WINDOW_MINUTES)
+            row = db.execute(text(
+                "SELECT COUNT(*) AS c FROM detection_events "
+                "WHERE user_id = :user_id AND notification_type = :type AND occurred_at >= :ws"
+            ), {"user_id": user_id, "type": notification_type, "ws": window_start}).fetchone()
+            count = row.c if row else 0
+
+            if count < ALERT_THRESHOLD:
+                decision, reason = False, f"{count}/{ALERT_THRESHOLD} below threshold"
+            else:
+                # 3) 쿨다운: 최근에 이미 알림을 보냈으면 스킵
+                cooldown_start = now - timedelta(minutes=ALERT_COOLDOWN_MINUTES)
+                last = db.execute(text(
+                    "SELECT MAX(sent_at) AS last_at FROM notification_logs "
+                    "WHERE from_user_id = :user_id AND notification_type = :type"
+                ), {"user_id": user_id, "type": notification_type}).fetchone()
+                if last and last.last_at and last.last_at >= cooldown_start:
+                    decision, reason = False, "in cooldown"
+                else:
+                    decision, reason = True, f"{count} in {ALERT_WINDOW_MINUTES}min -> send"
+        except Exception as e:
+            # DB 판정 실패 시에만 fail-open (로깅은 판정에 영향 주지 않음)
+            db.rollback()
+            logger.warning("[alert-throttle] check failed, fallback=send: %s", e)
+            return True
+
+        logger.info("[alert-throttle] %s user=%s: %s (send=%s)",
+                    notification_type, user_id, reason, decision)
+        return decision
+
     def update_notification_setting(self, request: NotificationSettingRequest, notification_type: str = 'danger') -> NotificationSettingResponse:
         """특정 구성원에 대한 알림 설정 변경
         
@@ -481,8 +534,9 @@ class NotificationService:
             
             db.commit()
             
-            # 3. 카운트가 증가했을 때만 자동 알림 발송
-            if request.danger_count > current_count.danger_count:
+            # 3. 카운트가 증가했고, 빈도 제한(윈도우 내 임계 이상)을 통과할 때만 자동 알림 발송
+            if request.danger_count > current_count.danger_count and \
+                    self._should_send_alert(db, request.user_id, "danger"):
                 auto_notification = AutoDangerNotificationRequest(
                     user_id=request.user_id,
                     danger_count=request.danger_count
@@ -622,8 +676,9 @@ class NotificationService:
             
             db.commit()
             
-            # 3. 카운트가 증가했을 때만 자동 알림 발송
-            if request.warning_count > current_count.warning_count:
+            # 3. 카운트가 증가했고, 빈도 제한(윈도우 내 임계 이상)을 통과할 때만 자동 알림 발송
+            if request.warning_count > current_count.warning_count and \
+                    self._should_send_alert(db, request.user_id, "warning"):
                 auto_notification = AutoWarningNotificationRequest(
                     user_id=request.user_id,
                     warning_count=request.warning_count


### PR DESCRIPTION
## 개요

감지될 때마다 그룹에 푸시하던 것을 **빈도 제한(throttle)** 합니다. 기본값: **윈도우(60분) 내 3회 이상** 감지 시에만 자동 알림 전송.

## 동작

- 감지(=`danger-count`/`warning-count` 증가)마다 `detection_events`에 기록.
- 최근 `ALERT_WINDOW_MINUTES`(기본 60분) 내 감지가 `ALERT_THRESHOLD`(기본 3) 이상이면 전송.
- 한 번 보내면 `ALERT_COOLDOWN_MINUTES`(기본 60분) 동안 재전송 안 함(연속 감지 도배 방지).
- **danger / warning 타입별로 독립** 집계.
- 적용 위치: `update_danger_count_with_notification` / `update_warning_count_with_notification`(감지 자동 경로). 수동 `POST /notifications/danger`·`/auto-danger`는 그대로 즉시 전송.

## 변경

- `notification_service.py`: `_should_send_alert()` 추가, 두 카운트 업데이트 메서드를 이 게이트로 감쌈. (로깅은 `print`→`logger`로 바꿔 콘솔 인코딩 에러가 판정에 영향 주지 않게 함)
- `sample_config.py` / `app/__init__.py`: `ALERT_THRESHOLD` / `ALERT_WINDOW_MINUTES` / `ALERT_COOLDOWN_MINUTES` 추가(조절 가능, 기본 3 / 60 / 60).

## ⚠️ 배포 전 DB 마이그레이션

코드 배포 **전에** 아래 테이블을 생성하세요.

```sql
CREATE TABLE IF NOT EXISTS detection_events (
  id BIGINT AUTO_INCREMENT PRIMARY KEY,
  user_id CHAR(36) NOT NULL,
  notification_type VARCHAR(10) NOT NULL,
  occurred_at DATETIME NOT NULL,
  INDEX idx_user_type_time (user_id, notification_type, occurred_at)
);
```
> 안전장치: 테이블이 없으면 throttle 판정이 실패하며 **기존처럼 전송(fail-open)** 합니다(500 안 남). 즉 마이그레이션을 안 하면 throttle만 비활성, 나머지는 정상.

## 테스트

- 감지 1·2회 → 보류(False), 3회째 → 전송(True), 쿨다운 중 4회째 → 보류(False) ✅
- danger/warning 타입별 독립 집계 ✅
- 컴파일 OK ✅

## 튜닝

`config.py`에서 기본값 조절 가능:
```python
ALERT_THRESHOLD = 3          # 예: 5로 올리면 더 보수적
ALERT_WINDOW_MINUTES = 60
ALERT_COOLDOWN_MINUTES = 60
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable notification rate limits for automatically triggered danger and warning alerts.
  * Alerts now only send after repeated detections within a time window, with a cooldown to reduce repeated notifications.
  * Default rate-limit settings are included in the sample configuration for easier setup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->