### PR TITLE
feat: 알림 전송 시 발신자 본인에게도 '전송됨' 확인 푸시

### DIFF
--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -282,9 +282,12 @@ class NotificationService:
             db.execute(text(
                 "UPDATE users SET danger_count = COALESCE(danger_count, 0) + 1 WHERE user_id = :user_id"
             ), {"user_id": request.from_user_id})
-            
+
             db.commit()
-            
+
+            # 발신자 본인에게도 '가족에게 알림 전송됨' 확인 푸시 (best-effort)
+            await self._notify_sender(db, request.from_user_id, "danger", sent_count)
+
             return DangerNotificationResponse(
                 success=True,
                 sent_count=sent_count,
@@ -376,6 +379,42 @@ class NotificationService:
         except Exception as e:
             print(f"[APNs] Error sending notification to {device_token}: {e}")
             return False
+
+    async def _send_self_push(self, device_token: str, body: str, level: str) -> bool:
+        """발신자 본인 기기로 확인용 푸시 (토큰 형식으로 APNs/FCM 분기, 임의 본문)."""
+        if is_apns_token(device_token):
+            try:
+                request = NotificationRequest(
+                    device_token=device_token,
+                    message={"aps": {"alert": body, "badge": 1}},
+                    notification_id=str(uuid4()),
+                    time_to_live=3,
+                    push_type=PushType.ALERT,
+                )
+                result = await self.apns_client.send_notification(request)
+                return result.is_successful
+            except Exception as e:
+                print(f"[self-alert][APNs] Error: {e}")
+                return False
+        return await self.fcm_pusher.send_notification(
+            device_token=device_token, body=body, from_user_id=None, level=f"self_{level}"
+        )
+
+    async def _notify_sender(self, db: Session, sender_user_id: str, level: str, sent_count: int):
+        """그룹원에게 알림이 나갔을 때, 발신자 본인에게도 '전송됨' 확인 푸시. (best-effort)"""
+        if sent_count <= 0:
+            return
+        try:
+            row = db.execute(text(
+                "SELECT device_token FROM users WHERE user_id = :u AND device_token IS NOT NULL"
+            ), {"u": sender_user_id}).fetchone()
+            if not row or not row.device_token:
+                return
+            level_ko = "위험" if level == "danger" else "주의"
+            body = f"가족 {sent_count}명에게 {level_ko} 알림을 보냈어요."
+            await self._send_self_push(row.device_token, body, level)
+        except Exception as e:
+            print(f"[self-alert] sender confirm failed (ignored): {e}")
     
     def get_notification_settings(self, user_id: str) -> List[dict]:
         """사용자의 모든 알림 설정 조회 (위험 및 경고)"""
@@ -494,9 +533,12 @@ class NotificationService:
                         "success": success,
                         "sent_at": notification_time
                     })
-            
+
             db.commit()
-            
+
+            # 발신자 본인에게도 '가족에게 알림 전송됨' 확인 푸시 (best-effort)
+            await self._notify_sender(db, request.user_id, "danger", sent_count)
+
             return DangerNotificationResponse(
                 success=True,
                 sent_count=sent_count,
@@ -636,9 +678,12 @@ class NotificationService:
                         "success": success,
                         "sent_at": notification_time
                     })
-            
+
             db.commit()
-            
+
+            # 발신자 본인에게도 '가족에게 알림 전송됨' 확인 푸시 (best-effort)
+            await self._notify_sender(db, request.user_id, "warning", sent_count)
+
             return DangerNotificationResponse(
                 success=True,
                 sent_count=sent_count,


### PR DESCRIPTION
## 개요

그룹원에게 위험/주의 알림이 나갈 때, **발신자 본인에게도 "가족에게 전송됨" 확인 푸시**를 보냅니다. 본인이 자기 감지가 가족에게 공유됐다는 걸 알 수 있게 하기 위함입니다.

## 동작

- 그룹원 전송이 1건 이상 성공하면(`sent_count > 0`), 발신자 본인 기기로:
  > `가족 {N}명에게 {위험|주의} 알림을 보냈어요.`
- **best-effort**: 본인 토큰이 없거나 전송 실패해도 메인 흐름엔 영향 없음.
- 적용 경로: `send_danger_notification`(수동) / `send_auto_danger_notification` / `send_auto_warning_notification`(감지 자동).

## 변경 (`notification_service.py`)

- `_send_self_push(device_token, body, level)`: 토큰 형식으로 APNs/FCM 분기해 **임의 본문**을 본인 기기로 전송. (FCM data `level=self_danger/self_warning`으로 마킹)
- `_notify_sender(db, sender_user_id, level, sent_count)`: 발신자 `device_token` 조회 후 위 확인 푸시. `sent_count<=0`이면 아무것도 안 함.
- 세 전송 메서드의 그룹원 루프 직후 `_notify_sender(...)` 호출.

## 테스트

- 멤버 존재 → 그룹원 전송 후 **본인에게 확인 푸시 1건**(토큰=발신자, 본문에 "위험", level="danger") ✅
- 멤버 0명(`sent_count=0`) → 본인 확인 푸시 **없음** ✅
- 컴파일 OK ✅

## 참고

- 별도 DB 마이그레이션 불필요.
- FCM data의 `level`을 `self_danger`/`self_warning`으로 보내므로, 클라가 원하면 본인 확인 알림을 다르게 표시할 수도 있음(현재는 본문 텍스트로 구분).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
