### PR TITLE
fix: 멤버 강퇴 시 'Unknown column user_name' 에러 수정

### DIFF
--- a/app/schemas/family_group.py
+++ b/app/schemas/family_group.py
@@ -66,6 +66,7 @@ class FamilyGroupKickMemberRequest(BaseModel):
 class FamilyGroupKickMemberResponse(BaseModel):
     success: bool = Field(..., description="추방 성공 여부")
     kicked_user_id: str = Field(..., description="추방된 사용자 ID")
+    kicked_user_name: Optional[str] = Field(None, description="추방된 사용자 닉네임")
     remaining_members: int = Field(..., description="남은 멤버 수")
     message: str = Field(..., description="결과 메시지")
 

--- a/app/services/family_group_service.py
+++ b/app/services/family_group_service.py
@@ -508,7 +508,7 @@ class FamilyGroupService:
             
             # 3. 대상 사용자가 그룹에 있는지 확인
             target_member = db.execute(text(
-                "SELECT user_name FROM group_members WHERE group_id = :group_id AND user_id = :user_id"
+                "SELECT nickname FROM group_members WHERE group_id = :group_id AND user_id = :user_id"
             ), {
                 "group_id": creator_group.id,
                 "user_id": request.target_user_id
@@ -551,9 +551,9 @@ class FamilyGroupService:
             return FamilyGroupKickMemberResponse(
                 success=True,
                 kicked_user_id=request.target_user_id,
-                kicked_user_name=target_member.user_name,
+                kicked_user_name=target_member.nickname,
                 remaining_members=remaining_count.count,
-                message=f"{target_member.user_name}님이 그룹에서 제거되었습니다."
+                message=f"{target_member.nickname}님이 그룹에서 제거되었습니다."
             )
             
         except Exception as e:


### PR DESCRIPTION
## 개요

그룹원 강퇴 시 발생하던 **`OperationalError (1054) Unknown column 'user_name' in 'field list'`** 를 수정합니다.

## 원인

`kick_member_from_group`이 `group_members`에서 **`user_name`** 을 조회했지만, 실제 컬럼은 **`nickname`** 입니다(그룹 생성 시 `group_members`에 `nickname`으로 삽입). 예전 `user_name → nickname` 정합 때 이 메서드가 누락돼 있었습니다.

```
SQL: SELECT user_name FROM group_members WHERE group_id=... AND user_id=...
→ (1054, "Unknown column 'user_name' in 'field list'")
```

## 변경

- `family_group_service.py` (`kick_member_from_group`):
  - `SELECT user_name FROM group_members` → `SELECT nickname ...`
  - `target_member.user_name` → `target_member.nickname` (응답 필드 + 메시지 2곳)
- `schemas/family_group.py`: `FamilyGroupKickMemberResponse`에 `kicked_user_name: Optional[str]` 추가.
  - 서비스가 이미 `kicked_user_name=...`을 넘기고 있었지만 스키마에 필드가 없어 **Pydantic이 조용히 무시**하던 값 → 이제 응답에 정상 포함.

## 테스트

- 강퇴 목 흐름: `success=True`, `kicked_user_name="민경"`, `remaining_members=2`, `message="민경님이 그룹에서 제거되었습니다."` — 예외 없이 **PASS** ✅
- 컴파일·전체 임포트 OK ✅

## 참고

- **DB 마이그레이션 불필요** (기존 `nickname` 컬럼 사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved family group member removal responses to show the member’s nickname/display name consistently.
  * Added a new response field so the kicked member’s name is included in the result.
  * Updated the success message to match the displayed nickname for clearer confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->