### PR TITLE
feat: POST /api/ml/labeled-csv — 라벨링 감지 CSV 수신 (학습 데이터 인박스)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ class Development(Config):
     # 로깅 설정
     LOG_LEVEL=INFO
     SQL_ECHO=false
+
+    # ML 라벨링 CSV 저장 디렉터리 (없으면 <repo>/data/ml_inbox)
+    # POST /api/ml/labeled-csv 로 수신한 라벨링 CSV(원시 바이트, BOM 보존)가 여기에 쌓인다.
+    # ml/phishing-classifier 학습 파이프라인의 import_csv.py 가 data/inbox/*.csv 를 glob 하므로,
+    # 운영 시 이 값을 그 inbox 로 지정하거나 해당 디렉터리로 rsync 한다.
+    ML_INBOX_DIR=/srv/ml/phishing-classifier/data/inbox
 ```
 
 ## Ollama 및 Gemma 3:4B 설치 가이드

--- a/app/api/endpoints/ml_data.py
+++ b/app/api/endpoints/ml_data.py
@@ -1,0 +1,114 @@
+from fastapi import APIRouter, HTTPException, Depends, status, Request
+from sqlalchemy.orm import Session
+from datetime import datetime
+import os
+import re
+import logging
+
+from app.core.database import get_db
+from app.repositories.user_repository import get_user_repository
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+# 라벨링 CSV 고정 헤더 — 안드로이드 클라와 합의한 스펙(순서/컬럼 불일치 시 422)
+EXPECTED_HEADER = "text,label,engine_verdict,patterns,score,source,app,timestamp"
+
+# 원시 바디 최대 크기(5MB) — 초과 시 413
+MAX_CSV_BYTES = 5 * 1024 * 1024
+
+# 저장 디렉터리 — 없으면 <repo>/data/ml_inbox 로 기본 설정.
+# ml/phishing-classifier 학습 파이프라인의 import_csv.py 가 data/inbox/*.csv 를 glob 하므로,
+# 서버 운영자는 ML_INBOX_DIR 를 그 inbox 로 지정하거나 이 디렉터리를 rsync 한다.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+ML_INBOX_DIR = os.environ.get("ML_INBOX_DIR", os.path.join(_REPO_ROOT, "data", "ml_inbox"))
+
+
+@router.post(
+    "/labeled-csv",
+    status_code=status.HTTP_201_CREATED,
+    summary="라벨링 CSV 업로드 (user_id 기반)",
+    description="클라 감지 이력 라벨링 CSV(원시 바디)를 그대로 수신해 학습 데이터로 서버에 저장한다. "
+                "본문은 UTF-8(BOM) text/csv, 헤더 한 줄이 스펙과 다르면 422로 거부한다.",
+)
+async def upload_labeled_csv(
+    request: Request,
+    user_id: str,
+    db: Session = Depends(get_db),
+):
+    """
+    라벨링 CSV 업로드 API
+
+    - user_id: 사용자 ID (쿼리 파라미터)
+    - body: 원시 CSV 바이트 (UTF-8 with BOM, Content-Type: text/csv; charset=utf-8)
+
+    auth/device-token 과 동일하게 user_id 기반으로 사용자 존재/활성 여부를 검증한다.
+    """
+    # 1) 사용자 검증 — 없거나 비활성이면 404
+    user_repo = get_user_repository(db)
+    user = user_repo.get_by_user_id(user_id)
+
+    if not user or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="사용자를 찾을 수 없음",
+        )
+
+    # 2) 원시 바디 수신 (python-multipart 미설치 — UploadFile/File 사용 금지)
+    body = await request.body()
+
+    if not body:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="빈 본문",
+        )
+
+    # 3) 5MB 초과 거부
+    if len(body) > MAX_CSV_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="CSV 크기 초과(최대 5MB)",
+        )
+
+    # 4) UTF-8(BOM) 디코딩 — 학습 임포터가 utf-8-sig 로 읽으므로 저장 시 BOM 은 보존한다.
+    try:
+        text = body.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="UTF-8 아님",
+        )
+
+    # 5) 고정 헤더 검증 — 첫 줄이 스펙과 다르면 422
+    first_line = text.split("\n", 1)[0].rstrip("\r")
+    if first_line != EXPECTED_HEADER:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="CSV 헤더 불일치",
+        )
+
+    # 6) 저장 — 디렉터리 보장 후, 충돌 안전 파일명으로 원시 바이트(BOM 포함) 그대로 기록
+    os.makedirs(ML_INBOX_DIR, exist_ok=True)
+
+    # 경로 조작 방지: user_id 를 안전 문자로 정규화(최대 64자)
+    safe_user_id = re.sub(r"[^A-Za-z0-9_-]", "_", user_id)[:64]
+    stamp = datetime.utcnow().strftime("%Y%m%dT%H%M%S_%f")[:-3]  # ms 정밀도
+    filename = f"{safe_user_id}_{stamp}.csv"
+    filepath = os.path.join(ML_INBOX_DIR, filename)
+
+    try:
+        with open(filepath, "wb") as f:
+            f.write(body)
+    except Exception as e:
+        logger.error(f"라벨링 CSV 저장 실패: user_id={user_id}, error={str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="CSV 저장 실패",
+        )
+
+    logger.info(f"라벨링 CSV 저장(POST /ml/labeled-csv): user_id={user_id}, file={filename}, bytes={len(body)}")
+    return {
+        "success": True,
+        "filename": filename,
+        "bytes": len(body),
+    }

--- a/app/api/routers.py
+++ b/app/api/routers.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api.endpoints import check_fraud, family_group, check_fraud_ws, kakao_login, notifications, auth
+from app.api.endpoints import check_fraud, family_group, check_fraud_ws, kakao_login, notifications, auth, ml_data
 
 router = APIRouter()
 
@@ -9,3 +9,4 @@ router.include_router(notifications.router, prefix="/notifications", tags=["noti
 router.include_router(check_fraud_ws.router, prefix="/ws/fraud", tags=["fraud-websocket"])
 router.include_router(kakao_login.router, prefix="/auth/kakao", tags=["kakao-login"])
 router.include_router(auth.router, prefix="/auth", tags=["auth"])
+router.include_router(ml_data.router, prefix="/ml", tags=["ml-data"])


### PR DESCRIPTION
## 개요

안드로이드 클라(감지 이력 화면 "서버로 보내기")가 호출하는 **`POST /api/ml/labeled-csv?user_id=<uid>`** 를 추가합니다. 사용자가 동의하고 전송한 라벨링 감지 CSV를 받아 **학습 데이터 인박스**에 저장합니다.

## 계약 (클라 `BackendApi.uploadLabeledCsv()`와 일치 — 교차 검증됨)

- `POST /api/ml/labeled-csv?user_id=<uid>` — 본문은 **원시 CSV 바이트** (UTF-8 + BOM, `Content-Type: text/csv`), 2xx = 성공.
- 고정 헤더: `text,label,engine_verdict,patterns,score,source,app,timestamp`
  — 안드로이드 `DetectionHistoryStore.exportCsv()` 및 학습 파이프라인 `import_csv.py`와 동일 스키마 확인.

## 동작

1. `user_id`로 사용자 존재/활성 검증 (기존 device-token 패턴) — 아니면 404
2. 원시 바디 수신 (신규 의존성 0 — python-multipart 불필요)
3. 검증: 빈 본문 400 / **5MB 초과 413** / UTF-8 아님 400 / **헤더 불일치 422**
4. `ML_INBOX_DIR`(env, 기본 `<repo>/data/ml_inbox`)에 `{safe_user_id}_{UTC타임스탬프}.csv`로 **BOM 포함 원시 바이트 그대로** 저장
   - 파일명 sanitize로 경로 조작 방지 (`../` 등 → `_`)

## 운영 (배포 시)

- `ML_INBOX_DIR`을 학습 파이프라인 inbox(`ml/phishing-classifier/data/inbox`)로 지정하거나, 기본 경로를 주기적으로 rsync.
- DB 마이그레이션 불필요.

## 테스트 (전부 PASS)

- 정상 업로드 201 + 파일 저장 + **BOM/바이트 완전 보존** ✅
- 없는 유저 404 / 빈 본문 400 / 헤더 불일치 422 / 5MB 초과 413 / 비 UTF-8 400 ✅
- 경로 조작 `user_id`(`../../evil%00name`) → `______evil_name_*.csv`로 정규화, inbox 밖 유출 0 ✅
- 컴파일·전체 라우터 임포트 OK ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
